### PR TITLE
Update the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const play = (audioBuffer: IAudioBuffer, audioContext: IAudioContext) => {
 A test suite for the `play()` function which will run with [Mocha](https://mochajs.org) and [Chai](https://www.chaijs.com) and uses `standardized-audio-context-mock` might look like this:
 
 ```js
-import { AudioBufferMock, AudioContextMock, registrar } from 'standardized-audio-context-mock';
+import { AudioBuffer, AudioContext, registrar } from 'standardized-audio-context-mock';
 
 describe('play()', () => {
 
@@ -49,8 +49,8 @@ describe('play()', () => {
     afterEach(() => registrar.reset());
 
     beforeEach(() => {
-        audioBufferMock = new AudioBufferMock({ length: 10, sampleRate: 44100 });
-        audioContextMock = new AudioContextMock();
+        audioBufferMock = new AudioBuffer({ length: 10, sampleRate: 44100 });
+        audioContextMock = new AudioContext();
     });
 
     it('should create a new AudioBufferSourceNode', () => {

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ npm install standardized-audio-context-mock
 Let's say you have the following code that you want to test:
 
 ```typescript
+// File `./play.ts`
 import { IAudioBuffer, IAudioContext } from 'standardized-audio-context';
 
-const play = (audioBuffer: IAudioBuffer, audioContext: IAudioContext) => {
+export const play = (audioBuffer: IAudioBuffer, audioContext: IAudioContext) => {
     const audioBufferSourceNode = audioContext.createBufferSource();
 
     audioBufferSourceNode.buffer = audioBuffer;
@@ -39,7 +40,9 @@ const play = (audioBuffer: IAudioBuffer, audioContext: IAudioContext) => {
 A test suite for the `play()` function which will run with [Mocha](https://mochajs.org) and [Chai](https://www.chaijs.com) and uses `standardized-audio-context-mock` might look like this:
 
 ```js
+// File `./play.test.js`
 import { AudioBuffer, AudioContext, registrar } from 'standardized-audio-context-mock';
+import { play } from './play'
 
 describe('play()', () => {
 


### PR DESCRIPTION
Hi, while trying to set up mocking I noticed some (probably) outdated usage in the README example.

I think the imports don't have the `Mock` postfix, so the import should `AudioContext` instead of `AudioContextMock`.

I also update the `jest`/`expect` syntax to a more recent signature, since I also got errors on the older `.to.have...` syntax. I did this in a separate commit so it can also be dropped if you want to keep the older syntax for some reason.

That said, I still only got 2 of the 4 tests to succeed. 

The 2 that failed said that `audioBufferSourceNodeMock.connect` and `audioBufferSourceNodeMock.start` weren't spy methods. I didn't dive any deeper to see how I could fix that, or even if that needs fixing.

Hope this helps, and let me know if this PR still needs changes.