### PR TITLE
fix(panner): retain panningModel similar to filter types (only if valid)

### DIFF
--- a/src/panner-node-mock.ts
+++ b/src/panner-node-mock.ts
@@ -161,8 +161,10 @@ export class PannerNodeMock<T extends TContext> extends AudioNodeMock<T> impleme
         return this._panningModel;
     }
 
-    set panningModel(value) {
-        value; // tslint:disable-line:no-unused-expression
+    set panningModel(value: TPanningModelType) {
+        if (['equalpower', 'HRTF'].includes(value)) {
+            this._panningModel = value;
+        }
     }
 
     get positionX(): AudioParamMock {


### PR DESCRIPTION
Just as we do with filter types, we should hold on to the panning model.